### PR TITLE
Add helper `selectLatestNightlyWith` and tweak docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ Running `nix develop` will create a shell with the default nightly Rust toolchai
     stable = {
       # The latest stable toolchain.
       latest = {
-        # [Experimental]
         # Profiles, predefined component sets.
         # See: https://rust-lang.github.io/rustup/concepts/profiles.html
         minimal = «derivation»;  # Only `cargo`, `rustc` and `rust-std`.
@@ -211,8 +210,7 @@ Some examples (assume `nixpkgs` had the overlay applied):
 
 - Latest stable/beta/nightly rust with almost all components (provided the same as `mozilla-overlay`):
   `nixpkgs.rust-bin.{stable,beta,nightly}.latest.rust`
-- *\[Experimental\]*
-  Latest stable/beta/nightly rust with `default` or `minimal` profile (provided the same as default behavior of `rustup install`).
+- Latest stable/beta/nightly rust with `default` or `minimal` profile (provided the same as default behavior of `rustup install`).
   `nixpkgs.rust-bin.{stable,beta,nightly}.latest.{default,minimal}`
 
   Note: `default` profile on `nightly` may not always be available due to absense of required components.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ Running `nix develop` will create a shell with the default nightly Rust toolchai
     # Same as `fromRustupToolchain` but read from a `rust-toolchain` file (legacy one-line string or in TOML).
     fromRustupToolchainFile = rust-toolchain-file-path: «derivation»;
 
+    # Select the latest nightly toolchain which have specific components or profile available.
+    # This helps nightly users in case of latest nightly may not contains all components they want.
+    #
+    # `selectLatestNightlyWith (toolchain: toolchain.default)` selects the latest nightly toolchain
+    # with all `default` components (rustc, cargo, rustfmt, ...) available.
+    selectLatestNightlyWith = selector: «derivation»;
+
     # [Experimental]
     # Custom toolchain from a specific rustc git revision.
     # This does almost the same thing as `rustup-toolchain-install-master`. (https://crates.io/crates/rustup-toolchain-install-master)
@@ -179,6 +186,9 @@ Running `nix develop` will create a shell with the default nightly Rust toolchai
 
     nightly = {
       # The latest nightly toolchain.
+      # It is preferred to use `selectLatestNightlyWith` instead of this since
+      # nightly toolchain may have components (like `rustfmt` or `rls`) missing,
+      # making `default` profile unusable.
       latest = { /* toolchain */ };
       "2020-12-31" = { /* toolchain */ };
       "2020-12-30" = { /* toolchain */ };
@@ -222,6 +232,14 @@ Some examples (assume `nixpkgs` had the overlay applied):
     extensions = [ "rust-src" ];
     targets = [ "arm-unknown-linux-gnueabihf" ];
   }
+  ```
+
+- Select the latest nightly toolchain with default components and `llvm-tools-preview` all available.
+  It may select toolchain earlier than `rust-bin.nightly.latest` due to lack of components.
+  ```nix
+  rust-bin.selectLatestNightlyWith (toolchain: toolchain.default.override {
+    extensions = [ "llvm-tools-preview" ];
+  })
   ```
 
 - If you already have a [`rust-toolchain` file for rustup][rust-toolchain],

--- a/flake.nix
+++ b/flake.nix
@@ -164,7 +164,9 @@
           });
       };
 
-      checkDrvs = {};
+      checkDrvs = lib.optionalAttrs (lib.elem system [ "aarch64-linux" "x86_64-linux" ]) {
+        latest-nightly-default = rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+      };
 
       failedAssertions =
         lib.filter (msg: msg != null) (

--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -559,22 +559,21 @@ let
 
 in {
   # For each channel:
-  #   rust-bin.stable.latest.cargo
-  #   rust-bin.stable.latest.rust   # Aggregate all others. (recommended)
+  #   rust-bin.stable.latest.{minimal,default,complete} # Profiles.
+  #   rust-bin.stable.latest.rust   # Pre-aggregate from upstream.
+  #   rust-bin.stable.latest.cargo  # Components...
   #   rust-bin.stable.latest.rustc
-  #   rust-bin.stable.latest.rust-analysis
   #   rust-bin.stable.latest.rust-docs
-  #   rust-bin.stable.latest.rust-src
-  #   rust-bin.stable.latest.rust-std
+  #   ...
   #
   # For a specific version of stable:
-  #   rust-bin.stable."1.47.0".rust
+  #   rust-bin.stable."1.47.0".default
   #
   # For a specific date of beta:
-  #   rust-bin.beta."2021-01-01".rust
+  #   rust-bin.beta."2021-01-01".default
   #
   # For a specific date of nightly:
-  #   rust-bin.nightly."2020-01-01".rust
+  #   rust-bin.nightly."2020-01-01".default
   rust-bin = with builtins;
     (super.rust-bin or {}) //
     mapAttrs (channel: mapAttrs (version: toolchainFromManifest)) super.rust-bin.manifests //


### PR DESCRIPTION
This helps nightly users from manually selecting date having some components available.

Related: #34 #14 