### PR TITLE
Fix cross-compilation

### DIFF
--- a/rust-overlay.nix
+++ b/rust-overlay.nix
@@ -299,14 +299,17 @@ let
         # Need to do it manually.
         mkdir -p "$out/nix-support"
         echo "$propagatedBuildInputs" > "$out/nix-support/propagated-build-inputs"
-        if [[ -n "$depsTargetTargetPropagated" ]]; then
-          echo "$depsTargetTargetPropagated" > "$out/nix-support/propagated-target-target-deps"
+        if [[ -n "$propagatedNativeBuildInputs" ]]; then
+          echo "$propagatedNativeBuildInputs" > "$out/nix-support/propagated-native-build-inputs"
         fi
       '';
 
       # FIXME: If these propagated dependencies go components, darwin build will fail with "`-liconv` not found".
-      propagatedBuildInputs = [ self.stdenv.cc ];
-      depsTargetTargetPropagated =
+
+      # use propagatedNativebuildinputs here because we want these dependencies to end up
+      # as buildPlatform dependencies on the derivation using the compiler even though
+      # they are targetPlatform dependencies from the compiler's perspective
+      propagatedNativeBuildInputs = [ self.stdenv.cc self.targetPackages.stdenv.cc ] ++
         self.lib.optional (self.stdenv.targetPlatform.isDarwin) self.targetPackages.libiconv;
 
       meta.platforms = self.lib.platforms.all;


### PR DESCRIPTION
It seems like there has been a mixup on what the build, host and target platforms are. To
quote the Nixpkgs manual: "In summary, build is the platform on which a package is being
built, host is the platform on which it will run. The third attribute, target, is relevant
only for certain specific compilers and build tools."

This is what I think was intended and lets us successfully cross compile from linux and
macOS to WASI and Windows, something that was broken before where native dependencies would leak into the cross-compile.

Fixes #40 