### PR TITLE
Shift Nix Platform Offsets Minus One

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
       inherit (pkgs) rust-bin rustChannelOf;
       inherit (pkgs.rust-bin) fromRustupToolchain fromRustupToolchainFile stable beta nightly;
 
-      rustTarget = pkgs.rust.toRustTarget pkgs.hostPlatform;
+      rustTarget = pkgs.rust.toRustTarget pkgs.buildPlatform;
 
       assertEq = lhs: rhs: {
         assertion = lhs == rhs;


### PR DESCRIPTION
Rust uses host-target terminology.  From the perspective of serving toolchains,
this makes sense.  You are on a build platform and distributing toolchains to
run on hosts and generate outputs for targets.

However, from the perspective of the person downloading a toolchain, they are
seeking a compiler for their buildPlatform to generate outputs for their
hostPlatform, where their Rust program will run.

This change shifts most targets to host and hosts to build.

When providing build inputs for a native or cross build, depsBuildHost are
available during build time to make outputs for the host.  Therefore, we
propagate libiconv for linking into the outputs on the host.  depsBuildHost is
also known as nativeBuildInputs.  propagatedNativeBuildInputs could also be used
here.

https://nixos.org/manual/nixpkgs/stable/#variables-specifying-dependencies

Aiming to fix #57 

Currently downloading the gigabyte of deps for the wasi target.  Seems to be working.  I'll have the cargo2nix branch with the example my version of the overlay up pretty soon.