### PR TITLE
Update docs to use rust-overlay.overlays.default instead of deprecate…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here's an example of using it in nixos configuration.
         modules = [
           ./configuration.nix # Your system configuration.
           ({ pkgs, ... }: {
-            nixpkgs.overlays = [ rust-overlay.overlay ];
+            nixpkgs.overlays = [ rust-overlay.overlays.default ];
             environment.systemPackages = [ pkgs.rust-bin.stable.latest.default ];
           })
         ];


### PR DESCRIPTION
Fixes [#104](https://github.com/oxalica/rust-overlay/issues/104) by switching from rust-overlay.overlay to rust-overlay.overlays.default in the README.