### PR TITLE
mk-component-set.nix: addAutoPatchelfSearchPath ${stdenv.cc.cc.libgcc}/lib

### DIFF
--- a/mk-component-set.nix
+++ b/mk-component-set.nix
@@ -80,6 +80,14 @@ let
         fi
       '';
 
+      # Adapation for https://github.com/NixOS/nixpkgs/pull/209870;
+      # something similar will go upstream in nixpkgs for all
+      # autoPatchelfHook users.  When it does, this can be dropped.
+      preFixup = lib.optionalString (stdenv?cc.cc.libgcc) ''
+        set -x
+        addAutoPatchelfSearchPath ${stdenv.cc.cc.libgcc}/lib
+      '';
+
       # Only contain tons of html files. Don't waste time scanning files.
       dontFixup = elem pname [ "rust-docs" "rustc-docs" ];
 


### PR DESCRIPTION
Closes #121

This is slightly ugly; something similar ought to go upstream in
nixpkgs so other users of autoPatchelfHook can benefit from it.
I'll do that next but I have to be a bit more careful there and need
to consider whether or not it will trigger a ton of rebuilds.