### PR TITLE
Rework flake and overlay structures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,13 +82,20 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust-channel: [stable, beta, nightly]
         profile: [minimal, default]
-        nixpkgs-channel: [nixpkgs-unstable, nixos-22.11]
+        nixpkgs-channel: [nixpkgs-unstable, nixos-22.05]
+        exclude:
+          # Stable channel is not for macOS.
+          - os: macos-latest
+            nixpkgs-channel: nixos-22.05
         include:
           # The legacy package, used by compatible functions.
           - os: ubuntu-latest
             rust-channel: stable
             profile: rust
             nixpkgs-channel: nixpkgs-unstable
+          # Use old Nix for stable channels.
+          - nixpkgs-channel: nixos-22.05
+            nix_install_url: https://releases.nixos.org/nix/nix-2.8.1/install
 
     runs-on: ${{ matrix.os }}
     env:

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,92 @@
+# The overlay.
 final: prev:
-(import ./rust-overlay.nix final) (prev // (import ./manifest.nix final prev))
+let
+  inherit (builtins) mapAttrs trace;
+
+  manifests = import ./manifest.nix {
+    inherit (final) lib;
+    inherit (final.rust-bin) distRoot;
+  };
+
+  inherit (import ./lib.nix { inherit (final) lib pkgs rust-bin; })
+    fromRustcRev
+    fromRustupToolchain
+    fromRustupToolchainFile
+    overrideToolchain
+    selectLatestNightlyWith
+    selectManifest
+    toolchainFromManifest
+    toolchainFromManifestFile
+    ;
+
+in {
+  # For each channel:
+  #   rust-bin.stable.latest.{minimal,default,complete} # Profiles.
+  #   rust-bin.stable.latest.rust   # Pre-aggregate from upstream.
+  #   rust-bin.stable.latest.cargo  # Components...
+  #   rust-bin.stable.latest.rustc
+  #   rust-bin.stable.latest.rust-docs
+  #   ...
+  #
+  # For a specific version of stable:
+  #   rust-bin.stable."1.47.0".default
+  #
+  # For a specific date of beta:
+  #   rust-bin.beta."2021-01-01".default
+  #
+  # For a specific date of nightly:
+  #   rust-bin.nightly."2020-01-01".default
+  rust-bin =
+    (prev.rust-bin or {}) //
+    mapAttrs (channel: mapAttrs (version: toolchainFromManifest)) manifests //
+    {
+      # The dist url for fetching.
+      # Override it if you want to use a mirror server.
+      distRoot = "https://static.rust-lang.org/dist";
+
+      inherit fromRustupToolchain fromRustupToolchainFile;
+      inherit selectLatestNightlyWith;
+      inherit fromRustcRev;
+
+      # For internal usage.
+      inherit manifests;
+    };
+
+  # All attributes below are for compatiblity with mozilla overlay.
+
+  lib = (prev.lib or {}) // {
+    rustLib = (prev.lib.rustLib or {}) // {
+      manifest_v2_url = throw ''
+        `manifest_v2_url` is not supported.
+        Select a toolchain from `rust-bin` or using `rustChannelOf` instead.
+        See also README at https://github.com/oxalica/rust-overlay
+      '';
+      fromManifest = throw ''
+        `fromManifest` is not supported due to network access during evaluation.
+        Select a toolchain from `rust-bin` or using `rustChannelOf` instead.
+        See also README at https://github.com/oxalica/rust-overlay
+      '';
+      fromManifestFile = manifestFilePath: { stdenv, fetchurl, patchelf }@deps: trace ''
+        `fromManifestFile` is deprecated.
+        Select a toolchain from `rust-bin` or using `rustChannelOf` instead.
+        See also README at https://github.com/oxalica/rust-overlay
+      '' (overrideToolchain deps (toolchainFromManifestFile manifestFilePath));
+    };
+  };
+
+  rustChannelOf = manifestArgs: toolchainFromManifest (selectManifest manifestArgs);
+
+  latest = (prev.latest or {}) // {
+    rustChannels = {
+      stable = final.rust-bin.stable.latest;
+      beta = final.rust-bin.beta.latest;
+      nightly = final.rust-bin.nightly.latest;
+    };
+  };
+
+  rustChannelOfTargets = channel: date: targets:
+    (final.rustChannelOf { inherit channel date; })
+      .rust.override { inherit targets; };
+
+  rustChannels = final.latest.rustChannels;
+}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -83,4 +83,4 @@ All public attributes provided by the overlay are below. Fields not defined here
 }
 ```
 
-For more details, see also the source code of [`rust-overlay.nix`](../rust-overlay.nix).
+For more details, see also the source code of [`default.nix`](../default.nix) and [`lib.nix`](../lib.nix).

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1681202837,
@@ -37,22 +39,21 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {
+      "flake": false,
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
+        "lastModified": 1,
+        "narHash": "sha256-zz/zMtmE95DrZPZ+eXAOHkD6pW4M4MaozQyIhYvP5xw=",
+        "path": "./systems.nix",
+        "type": "path"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "path": "./systems.nix",
+        "type": "path"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": [
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1681358109,
@@ -38,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -26,7 +26,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-zz/zMtmE95DrZPZ+eXAOHkD6pW4M4MaozQyIhYvP5xw=",
+        "narHash": "sha256-cyfZqnwhPNzdfQnmUUUVK5fon88TSm/0CwgE7Lf+LDU=",
         "path": "./systems.nix",
         "type": "path"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,15 @@
   '';
 
   inputs = {
+    # See: https://github.com/nix-systems/nix-systems
+    systems.url = "path:./systems.nix";
+    systems.flake = false;
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.inputs.systems.follows = "systems";
   };
 
-  outputs = { self, nixpkgs, flake-utils }: let
+  outputs = { self, systems, nixpkgs, flake-utils }: let
     inherit (nixpkgs.lib)
       elem filterAttrs head mapAttrs mapAttrs' optionalAttrs replaceStrings warnIf;
 
@@ -18,20 +22,7 @@
 
     overlay = import ./.;
 
-    allSystems = [
-      "aarch64-darwin"
-      "aarch64-linux"
-      "armv5tel-linux"
-      "armv6l-linux"
-      "armv7a-linux"
-      "armv7l-linux"
-      "i686-linux"
-      # "mipsel-linux" # Missing `busybox`.
-      "powerpc64le-linux"
-      "riscv64-linux"
-      "x86_64-darwin"
-      "x86_64-linux"
-    ];
+    allSystems = import systems;
 
   in {
     overlays = {

--- a/lib.nix
+++ b/lib.nix
@@ -1,10 +1,10 @@
-# Define component resolution and utility functions.
-self: super:
+# Component resolution, aggregation and other utility functions.
+{ lib, pkgs, rust-bin }:
 
 let
   inherit (builtins) compareVersions fromTOML match readFile tryEval;
 
-  inherit (self.lib)
+  inherit (lib)
     any attrNames attrValues concatStringsSep elem elemAt filter flatten foldl'
     hasPrefix head isString length listToAttrs makeOverridable mapAttrs
     mapAttrsToList optional optionalAttrs replaceStrings substring trace unique;
@@ -20,22 +20,22 @@ let
     if platform.isWasi then
       "${platform.parsed.cpu.name}-wasi"
     else
-      self.rust.toRustTarget platform;
+      pkgs.rust.toRustTarget platform;
 
   # The platform where `rustc` is running.
-  rustHostPlatform = toRustTarget self.stdenv.hostPlatform;
+  rustHostPlatform = toRustTarget pkgs.stdenv.hostPlatform;
   # The platform of binary which `rustc` produces.
-  rustTargetPlatform = toRustTarget self.stdenv.targetPlatform;
+  rustTargetPlatform = toRustTarget pkgs.stdenv.targetPlatform;
 
-  mkComponentSet = self.callPackage ./mk-component-set.nix {
+  mkComponentSet = pkgs.callPackage ./mk-component-set.nix {
     inherit toRustTarget removeNulls;
   };
 
-  mkAggregated = self.callPackage ./mk-aggregated.nix {};
+  mkAggregated = pkgs.callPackage ./mk-aggregated.nix {};
 
   # Manifest selector.
   selectManifest = { channel, date ? null }: let
-    inherit (self.rust-bin) manifests;
+    inherit (rust-bin) manifests;
 
     assertWith = cond: msg: body: if cond then body else throw msg;
 
@@ -127,7 +127,7 @@ let
       matchParenPart = match ".*/([^ /]*) [(][^)]*[)](.*)" url;
       name = if matchParenPart == null then "" else (elemAt matchParenPart 0) + (elemAt matchParenPart 1);
     in
-      self.fetchurl { inherit name sha256; url = url'; };
+      pkgs.fetchurl { inherit name sha256; url = url'; };
 
   # Resolve final components to install from mozilla-overlay style `extensions`, `targets` and `targetExtensions`.
   #
@@ -252,8 +252,6 @@ let
   #                       *Attention* If you want to install an extension like rust-src, that has no fixed architecture (arch *),
   #                       you will need to specify this extension in the extensions options or it will not be installed!
   toolchainFromManifest = manifest: let
-    maybeRename = name: manifest.renames.${name}.to or name;
-
     # platform -> true
     # For fail-fast test.
     allPlatformSet =
@@ -370,7 +368,7 @@ let
     target ? rustTargetPlatform
   }: let
     hashToSrc = compName: hash:
-      self.fetchurl {
+      pkgs.fetchurl {
         url = if compName == "rust-src"
           then "https://ci-artifacts.rust-lang.org/rustc-builds/${rev}/${compName}-nightly.tar.xz"
           else "https://ci-artifacts.rust-lang.org/rustc-builds/${rev}/${compName}-nightly-${target}.tar.xz";
@@ -394,10 +392,10 @@ let
   # `selectLatestNightlyWith (toolchain: toolchain.default.override { extensions = ["llvm-tools-preview"]; })`
   selectLatestNightlyWith = selector:
     let
-      nightlyDates = attrNames (removeAttrs self.rust-bin.nightly [ "latest" ]);
+      nightlyDates = attrNames (removeAttrs rust-bin.nightly [ "latest" ]);
       dateLength = length nightlyDates;
       go = idx:
-        let ret = selector (self.rust-bin.nightly.${elemAt nightlyDates idx}); in
+        let ret = selector (rust-bin.nightly.${elemAt nightlyDates idx}); in
         if idx == 0 then
           ret
         else if dateLength - idx >= 256 then
@@ -410,66 +408,14 @@ let
       go (length nightlyDates - 1);
 
 in {
-  # For each channel:
-  #   rust-bin.stable.latest.{minimal,default,complete} # Profiles.
-  #   rust-bin.stable.latest.rust   # Pre-aggregate from upstream.
-  #   rust-bin.stable.latest.cargo  # Components...
-  #   rust-bin.stable.latest.rustc
-  #   rust-bin.stable.latest.rust-docs
-  #   ...
-  #
-  # For a specific version of stable:
-  #   rust-bin.stable."1.47.0".default
-  #
-  # For a specific date of beta:
-  #   rust-bin.beta."2021-01-01".default
-  #
-  # For a specific date of nightly:
-  #   rust-bin.nightly."2020-01-01".default
-  rust-bin =
-    (super.rust-bin or {}) //
-    mapAttrs (channel: mapAttrs (version: toolchainFromManifest)) super.rust-bin.manifests //
-    {
-      inherit fromRustupToolchain fromRustupToolchainFile;
-      inherit selectLatestNightlyWith;
-      inherit fromRustcRev;
-    };
-
-  # All attributes below are for compatiblity with mozilla overlay.
-
-  lib = (super.lib or {}) // {
-    rustLib = (super.lib.rustLib or {}) // {
-      manifest_v2_url = throw ''
-        `manifest_v2_url` is not supported.
-        Select a toolchain from `rust-bin` or using `rustChannelOf` instead.
-        See also README at https://github.com/oxalica/rust-overlay
-      '';
-      fromManifest = throw ''
-        `fromManifest` is not supported due to network access during evaluation.
-        Select a toolchain from `rust-bin` or using `rustChannelOf` instead.
-        See also README at https://github.com/oxalica/rust-overlay
-      '';
-      fromManifestFile = manifestFilePath: { stdenv, fetchurl, patchelf }@deps: trace ''
-        `fromManifestFile` is deprecated.
-        Select a toolchain from `rust-bin` or using `rustChannelOf` instead.
-        See also README at https://github.com/oxalica/rust-overlay
-      '' (overrideToolchain deps (toolchainFromManifestFile manifestFilePath));
-    };
-  };
-
-  rustChannelOf = manifestArgs: toolchainFromManifest (selectManifest manifestArgs);
-
-  latest = (super.latest or {}) // {
-    rustChannels = {
-      stable = self.rust-bin.stable.latest;
-      beta = self.rust-bin.beta.latest;
-      nightly = self.rust-bin.nightly.latest;
-    };
-  };
-
-  rustChannelOfTargets = channel: date: targets:
-    (self.rustChannelOf { inherit channel date; })
-      .rust.override { inherit targets; };
-
-  rustChannels = self.latest.rustChannels;
+  inherit
+    fromRustcRev
+    fromRustupToolchain
+    fromRustupToolchainFile
+    overrideToolchain
+    selectLatestNightlyWith
+    selectManifest
+    toolchainFromManifest
+    toolchainFromManifestFile
+    ;
 }

--- a/manifest.nix
+++ b/manifest.nix
@@ -1,15 +1,14 @@
-final: prev:
+# Manifests which describe the content of each version.
+{ lib, distRoot }:
 let
   inherit (builtins) match isString toString;
 
-  inherit (final.lib)
+  inherit (lib)
     attrNames concatMap elemAt filter hasAttr mapAttrs mapAttrs' removeSuffix;
 
   targets = import ./manifests/targets.nix // { _ = "*"; };
   renamesList = import ./manifests/renames.nix;
   profilesList = import ./manifests/profiles.nix;
-
-  inherit (final.rust-bin) distRoot;
 
   # Extensions for mixed `rust` pkg.
   components = [
@@ -110,16 +109,7 @@ let
   in ret // { latest = ret.${set.latest}; };
 
 in {
-  rust-bin = (prev.rust-bin or {}) // {
-    # The dist url for fetching.
-    # Override it if you want to use a mirror server.
-    distRoot = "https://static.rust-lang.org/dist";
-
-    # For internal usage.
-    manifests = {
-      stable  = uncompressManifestSet "stable"  (import ./manifests/stable);
-      beta    = uncompressManifestSet "beta"    (import ./manifests/beta);
-      nightly = uncompressManifestSet "nightly" (import ./manifests/nightly);
-    };
-  };
+  stable  = uncompressManifestSet "stable"  (import ./manifests/stable);
+  beta    = uncompressManifestSet "beta"    (import ./manifests/beta);
+  nightly = uncompressManifestSet "nightly" (import ./manifests/nightly);
 }

--- a/systems.nix
+++ b/systems.nix
@@ -1,0 +1,14 @@
+[
+  "aarch64-darwin"
+  "aarch64-linux"
+  "armv5tel-linux"
+  "armv6l-linux"
+  "armv7a-linux"
+  "armv7l-linux"
+  "i686-linux"
+  # "mipsel-linux" # Missing `busybox`.
+  "powerpc64le-linux"
+  "riscv64-linux"
+  "x86_64-darwin"
+  "x86_64-linux"
+]

--- a/systems.nix
+++ b/systems.nix
@@ -3,10 +3,9 @@
   "aarch64-linux"
   "armv5tel-linux"
   "armv6l-linux"
-  "armv7a-linux"
   "armv7l-linux"
   "i686-linux"
-  # "mipsel-linux" # Missing `busybox`.
+  "mipsel-linux"
   "powerpc64le-linux"
   "riscv64-linux"
   "x86_64-darwin"


### PR DESCRIPTION
- Drops flake-utils and follows https://github.com/nix-systems/nix-systems to allow overriding systems.
- Split the overlay interface from packaging/toolchain-selection logic.
- Avoid the need of `import nixpkgs`, as stated in #94

It would be good to export functions in `lib.nix` under `lib` flake output. But it's not easy since `select*` depends on unpacked `manifests`, which depends on `pkgs`. Using interface `lib.select* = pkgs: <drv>` would unpack manifests every time when called.