### PR TITLE
mk-aggregated: Also dereference librustc_driver in rustlib

### DIFF
--- a/mk-aggregated.nix
+++ b/mk-aggregated.nix
@@ -58,6 +58,11 @@ symlinkJoin {
     for file in $out/lib/librustc_driver*; do
       cp --remove-destination "$(realpath -e $file)" $file
     done
+
+    # installed with rustc-dev
+    for file in $out/lib/rustlib/*/lib/librustc_driver*; do
+      cp --remove-destination "$(realpath -e $file)" $file
+    done
   ''
   + ''
     if [ -e $out/bin/cargo-miri ]; then


### PR DESCRIPTION
A copy of librustc_driver is installed into `lib/rustlib/$target/lib` with rustc-dev. This is added to `LD_LIBRARY_PATH` by Cargo when it executes build scripts. Without this fix, rustc triggered from build scripts would see the wrong sysroot.

This extends be3a8a8b59aaec5cd96d3ea6e4470bd14bdd8b37 to cover the additional case.

## Reproduction

Use this `build.rs`:

```rust
use std::process::Command;

fn main() {
    let ld_library_path = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
    eprintln!("LD_LIBRARY_PATH={}", ld_library_path);

    let sysroot = Command::new("rustc")
        .args(&["--print", "sysroot"])
        .output()
        .unwrap();
    let sysroot = std::str::from_utf8(&sysroot.stdout).unwrap().trim();
    eprintln!("  Actual sysroot: {}", sysroot);

    let sysroot_no_path = Command::new("rustc")
        .args(&["--print", "sysroot"])
        .env_remove("LD_LIBRARY_PATH")
        .output()
        .unwrap();
    let sysroot_no_path = std::str::from_utf8(&sysroot_no_path.stdout).unwrap().trim();
    eprintln!("Expected sysroot: {}", sysroot_no_path);

    panic!();
}
```

With a `default` install, everything seems to be fine:

```
  LD_LIBRARY_PATH=/home/zhaofeng/Git/autocfg-53-repro/target/debug/deps:/home/zhaofeng/Git/autocfg-53-repro/target/debug:/nix/store/2j8bc4j3r29d80f9ks5imdp1x5031yaq-rust-default-1.68.0/lib/rustlib/x86_64-unknown-linux-gnu/lib:/nix/store/9sjvc68gh7mbnjiaakxv3jpnwq7hgj6h-pipewire-0.3.71-jack/lib
    Actual sysroot: /nix/store/2j8bc4j3r29d80f9ks5imdp1x5031yaq-rust-default-1.68.0
  Expected sysroot: /nix/store/2j8bc4j3r29d80f9ks5imdp1x5031yaq-rust-default-1.68.0
```

However, with `rustc-dev` added:

```
  LD_LIBRARY_PATH=/home/zhaofeng/Git/autocfg-53-repro/target/debug/deps:/home/zhaofeng/Git/autocfg-53-repro/target/debug:/nix/store/ci5fg55zncji0x7nan23kdwpk2q6vxxb-rust-default-1.68.0/lib/rustlib/x86_64-unknown-linux-gnu/lib:/nix/store/9sjvc68gh7mbnjiaakxv3jpnwq7hgj6h-pipewire-0.3.71-jack/lib
    Actual sysroot: /nix/store/bmjdx9dpp81kkdabn42h87wagvrpy9kv-rustc-dev-1.68.0-x86_64-unknown-linux-gnu
  Expected sysroot: /nix/store/ci5fg55zncji0x7nan23kdwpk2q6vxxb-rust-default-1.68.0
```