### PR TITLE
fix sandbox builds on ventura

### DIFF
--- a/mk-aggregated.nix
+++ b/mk-aggregated.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, symlinkJoin, pkgsTargetTarget, bash }:
+{ lib, stdenv, symlinkJoin, pkgsTargetTarget, bash, curl }:
 { pname, version, date, selectedComponents, availableComponents ? selectedComponents }:
 let
   inherit (lib) optional;
@@ -54,6 +54,14 @@ symlinkJoin {
         ''}
       fi
     done
+    ${lib.optionalString stdenv.isDarwin ''
+      cargo="$out/bin/cargo"
+      if [ -e "$cargo" ]; then
+        cp --remove-destination "$(realpath -e $cargo)" "$cargo"
+        chmod +w "$cargo"
+        install_name_tool -change "/usr/lib/libcurl.4.dylib" "${curl.out}/lib/libcurl.4.dylib" "$cargo"
+      fi
+    ''}
     shopt nullglob
     for file in $out/lib/librustc_driver*; do
       cp --remove-destination "$(realpath -e $file)" $file


### PR DESCRIPTION
The Cargo bundled in this project links against the operating system's libcurl. This can be demonstrated with

```
$ otool -L $(which cargo)
/nix/store/s8rb4j0rh3wm66r4hmgj4axcic321bak-rust-default-1.73.0/bin/cargo:
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60420.101.2)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1971.0.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

The system's libcurl dynamically depends on the system's libcrypto. On MacOS 14, this (at some point) opens `/private/etc/ssl/openssl.cnf`. With the Nix sandbox on, this fails the build with

```
       > 8082083840:error:02FFF001:system library:func(4095):Operation not permitted:/AppleInternal/Library/BuildRoots/0032d1ee-80fd-11ee-8227-6aecfccc70fe/Library/Caches/com.apple.xbs/Sources/libressl/libressl-3.3/crypto/bio/bss_file.c:122:fopen('/private/etc/ssl/openssl.cnf', 'rb')
       > 8082083840:error:20FFF002:BIO routines:CRYPTO_internal:system lib:/AppleInternal/Library/BuildRoots/0032d1ee-80fd-11ee-8227-6aecfccc70fe/Library/Caches/com.apple.xbs/Sources/libressl/libressl-3.3/crypto/bio/bss_file.c:127:
       > 8082083840:error:0EFFF002:configuration file routines:CRYPTO_internal:system lib:/AppleInternal/Library/BuildRoots/0032d1ee-80fd-11ee-8227-6aecfccc70fe/Library/Caches/com.apple.xbs/Sources/libressl/libressl-3.3/crypto/conf/conf_def.c:202:
       For full logs, run 'nix log /nix/store/h05s2pzw6qb5m50njk0vr7j6cimhcxmj-foo.drv'.
```

as reported in https://github.com/oxalica/rust-overlay/issues/148.

This could be 'fixed' in three places.

1. On the Apple side. This probably won't happen.
2. Inside Nix, by changing the sandbox definition. I'd argue that since this bug isn't really reachable with 'normal' Nix binaries (where you would link against the Nix openssl) it's not the ideal place to make the change. Additionally, it adds a Nix version dependency on usage of this tool. This is discussed here: https://github.com/NixOS/nix/issues/9625. For users where I work, this is painful as we deploy Nix using Nix darwin, and by default deploy a module using the Rust overlay, so we get a chicken and egg problem as each dev updates to Ventura.
3. Here. We can change the link to point to a nixpkgs version of libcurl rather than the OS provided version, and this avoids the MacOS libressl implementation. This feels right because it seems analogous to 'I tried to run a random binary on NixOS and it couldn't find `/lib64/ld-linux-x86-64.so.2`', traditionally a derivation author's responsibility.

I chose 3 as being likely the most pragmatic solution, so here we are!

After this MR, we have:

```
$ otool -L $(which cargo)
/nix/store/km3i2b7dqb1h2ayy2qg239266ixkzxgl-rust-default-1.75.0/bin/cargo:
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60420.101.2)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1971.0.0)
	/nix/store/c39qm57grkavw8a4hkramahpnspm1inq-curl-8.4.0/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
```

In theory it might be more consistent/better to additionally replace the various other links with more nixy links, but I figured that the surgical approach was less intrusive at this time.