### PR TITLE
Update README.md to narrow pkgs scope in nix develop segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,8 @@ Running `nix develop` will create a shell with the default beta Rust toolchain i
           inherit system overlays;
         };
       in
-      with pkgs;
       {
-        devShells.default = mkShell {
+        devShells.default = with pkgs; mkShell {
           buildInputs = [
             openssl
             pkg-config


### PR DESCRIPTION
relocated the ```with pkgs;``` statement to its typical location within the devshell.default assignment. This is a very minor change merely improving cohesion and nothing else