### PR TITLE
Catch stable channel more precisely

### DIFF
--- a/.github/workflows/sync-channels.yaml
+++ b/.github/workflows/sync-channels.yaml
@@ -4,7 +4,7 @@ on:
     # The nightly channel is usually updated at 01:00:00 UTC.
     - cron: '0 2 * * *' # *-*-* 02:00:00 UTC
     # The stable channel is usually updated before 17:00:00 UTC
-    - cron: '0 17 * * *' # *-*-* 17:00:00 UTC
+    - cron: '0 17 * * THU' # *-*-* 17:00:00 UTC
 
   workflow_dispatch:
 

--- a/.github/workflows/sync-channels.yaml
+++ b/.github/workflows/sync-channels.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     # The nightly channel is usually updated at 01:00:00 UTC.
     - cron: '0 2 * * *' # *-*-* 02:00:00 UTC
+    # The stable channel is usually updated before 17:00:00 UTC
+    - cron: '0 17 * * *' # *-*-* 17:00:00 UTC
 
   workflow_dispatch:
 


### PR DESCRIPTION
Add cron that will catch stable releases more precisely.