### PR TITLE
Fix mistake in nixos configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ Here's an example of using it in nixos configuration.
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { nixpkgs, rust-overlay, ... }: {


### PR DESCRIPTION
Mismatched versions of nixpkgs [can cause bugs with certain packages](https://github.com/tauri-apps/tauri/issues/8254).