### PR TITLE
Return target dep as flat list instead of nested list for darwin std

### DIFF
--- a/mk-aggregated.nix
+++ b/mk-aggregated.nix
@@ -27,7 +27,7 @@ symlinkJoin {
 
   # Link dependency for target, required by darwin std.
   depsTargetTargetPropagated =
-    optional (targetPlatform.isDarwin) [ pkgsTargetTarget.libiconv ];
+    optional (targetPlatform.isDarwin) pkgsTargetTarget.libiconv;
 
   # If rustc or rustdoc is in the derivation, we need to copy their
   # executable into the final derivation. This is required


### PR DESCRIPTION
It came out of [debugging a call to `overrideSDK` on a x86_64-darwin system on the Nix discourse](https://discourse.nixos.org/t/need-help-from-darwin-users-syntax-errors-in-library-frameworks-foundation-framework-headers/30467/8?u=jost-s), that the rust-overlay returns a nested list with `libiconv` as the only element. That caused the override to fail.

`lib.optional` takes any value and puts it into a list when the condition is met. In this case the value is wrapped in a list, so the result is a nested list.

```sh
nix-repl> legacyPackages.aarch64-darwin.lib.optional true ""                                       
[ "" ]

nix-repl> legacyPackages.aarch64-darwin.lib.optional true [""]
[ [ ... ] ]
```

I suggest to return a flat list instead, as is done a few lines up in the same file.