### PR TITLE
flake: remove compatibility with nix < 2.7 layout

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,10 +11,7 @@
 
   outputs = { self, nixpkgs, flake-utils }: let
     inherit (nixpkgs.lib)
-      elem filterAttrs head mapAttrs mapAttrs' optionalAttrs replaceStrings warnIf;
-
-    inherit (builtins)
-      nixVersion compareVersions;
+      elem filterAttrs head mapAttrs' optionalAttrs replaceStrings;
 
     overlay = import ./.;
 
@@ -38,18 +35,6 @@
       default = overlay;
       rust-overlay = overlay;
     };
-
-    # Compatible fields.
-    # Put them outside `eachSystem` to suppress duplicated warnings.
-    overlay =
-      warnIf (compareVersions nixVersion "2.7" >= 0)
-        "rust-overlay's flake output `overlay` is deprecated in favor of `overlays.default` for Nix >= 2.7"
-        overlay;
-    defaultPackage =
-      warnIf (compareVersions nixVersion "2.7" >= 0)
-        "rust-overlay's flake output `defaultPackage.<system>` is deprecated in favor of `packages.<system>.default` for Nix >= 2.7"
-        (mapAttrs (_: pkgs: pkgs.default) self.packages);
-
   } // flake-utils.lib.eachSystem allSystems (system: let
     pkgs = import nixpkgs { inherit system; overlays = [ overlay ]; };
   in {


### PR DESCRIPTION
To remove the warning on `nix flake check`.