### PR TITLE
examples: also use callPackage for flake

### DIFF
--- a/examples/cross-aarch64/flake.nix
+++ b/examples/cross-aarch64/flake.nix
@@ -6,24 +6,40 @@
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, rust-overlay, nixpkgs }: {
-    devShells.x86_64-linux.default = let
-      pkgs = nixpkgs.legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform;
-      rust-bin = rust-overlay.lib.mkRustBin { } pkgs.buildPackages;
-    in
-      pkgs.mkShell {
-        nativeBuildInputs = [
-          rust-bin.stable.latest.minimal
-          pkgs.buildPackages.pkg-config
-        ];
+  outputs =
+    {
+      self,
+      rust-overlay,
+      nixpkgs,
+    }:
+    {
+      devShells.x86_64-linux.default =
+        let
+          pkgsCross = nixpkgs.legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform;
+          rust-bin = rust-overlay.lib.mkRustBin { } pkgsCross.buildPackages;
+        in
+        pkgsCross.callPackage (
+          {
+            mkShell,
+            pkg-config,
+            qemu,
+            openssl,
+            stdenv,
+          }:
+          mkShell {
+            nativeBuildInputs = [
+              rust-bin.stable.latest.minimal
+              pkg-config
+            ];
 
-        depsBuildBuild = [ pkgs.pkgsBuildBuild.qemu ];
-        buildInputs = [ pkgs.openssl ];
+            depsBuildBuild = [ qemu ];
+            buildInputs = [ openssl ];
 
-        env = {
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "${pkgs.stdenv.cc.targetPrefix}cc";
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER = "qemu-aarch64";
-        };
-      };
-  };
+            env = {
+              CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "${stdenv.cc.targetPrefix}cc";
+              CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER = "qemu-aarch64";
+            };
+          }
+        ) { };
+    };
 }


### PR DESCRIPTION
This avoids manual package spliting and should be more user-friendly.