### PR TITLE
Adding libsecret to cargo to get `cargo login` to work

### DIFF
--- a/lib/mk-aggregated.nix
+++ b/lib/mk-aggregated.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, symlinkJoin, pkgsTargetTarget, bash, curl }:
+{ lib, stdenv, symlinkJoin, pkgsTargetTarget, bash, curl, libsecret }:
 { pname, version, date, selectedComponents, availableComponents ? selectedComponents }:
 let
   inherit (lib) optional;
@@ -56,6 +56,11 @@ symlinkJoin {
         ''}
       fi
     done
+    ${lib.optionalString stdenv.isLinux ''
+      cp --remove-destination "$(realpath -e $out/bin/cargo)" $out/bin/cargo
+      chmod +w $out/bin/cargo
+      patchelf --add-needed ${libsecret}/lib/libsecret-1.so.0 $out/bin/cargo
+    ''}
     ${lib.optionalString stdenv.isDarwin ''
       cargo="$out/bin/cargo"
       if [ -e "$cargo" ]; then

--- a/lib/mk-aggregated.nix
+++ b/lib/mk-aggregated.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, symlinkJoin, pkgsTargetTarget, bash, curl, libsecret }:
+{ lib, stdenv, symlinkJoin, pkgsTargetTarget, bash, curl }:
 { pname, version, date, selectedComponents, availableComponents ? selectedComponents }:
 let
   inherit (lib) optional;

--- a/lib/mk-aggregated.nix
+++ b/lib/mk-aggregated.nix
@@ -56,11 +56,6 @@ symlinkJoin {
         ''}
       fi
     done
-    ${lib.optionalString stdenv.isLinux ''
-      cp --remove-destination "$(realpath -e $out/bin/cargo)" $out/bin/cargo
-      chmod +w $out/bin/cargo
-      patchelf --add-needed ${libsecret}/lib/libsecret-1.so.0 $out/bin/cargo
-    ''}
     ${lib.optionalString stdenv.isDarwin ''
       cargo="$out/bin/cargo"
       if [ -e "$cargo" ]; then

--- a/lib/mk-component-set.nix
+++ b/lib/mk-component-set.nix
@@ -1,5 +1,5 @@
 # Define component derivations and special treatments.
-{ lib, stdenv, stdenvNoCC, gnutar, autoPatchelfHook, bintools, zlib, gccForLibs
+{ lib, stdenv, stdenvNoCC, gnutar, autoPatchelfHook, bintools, zlib, gccForLibs, libsecret
 # The path to nixpkgs root.
 , path
 , toRustTarget, removeNulls
@@ -139,6 +139,9 @@ let
             wrap "$dst" ${path + "/pkgs/build-support/bintools-wrapper/ld-wrapper.sh"} "$unwrapped"
           done
         fi
+      ''
+      + optionalString (stdenv.isLinux && pname == "cargo") ''
+        patchelf --add-needed ${libsecret}/lib/libsecret-1.so.0 $out/bin/cargo
       '';
 
       env = lib.optionalAttrs (pname == "rustc") {

--- a/lib/mk-component-set.nix
+++ b/lib/mk-component-set.nix
@@ -1,5 +1,6 @@
 # Define component derivations and special treatments.
-{ lib, stdenv, stdenvNoCC, gnutar, autoPatchelfHook, bintools, zlib, gccForLibs, libsecret
+{ lib, stdenv, stdenvNoCC, gnutar, autoPatchelfHook, bintools, zlib, gccForLibs
+, pkgsHostHost
 # The path to nixpkgs root.
 , path
 , toRustTarget, removeNulls
@@ -141,7 +142,7 @@ let
         fi
       ''
       + optionalString (stdenv.isLinux && pname == "cargo") ''
-        patchelf --add-needed ${libsecret}/lib/libsecret-1.so.0 $out/bin/cargo
+        patchelf --add-needed ${pkgsHostHost.libsecret}/lib/libsecret-1.so.0 $out/bin/cargo
       '';
 
       env = lib.optionalAttrs (pname == "rustc") {


### PR DESCRIPTION
On Linux, the recommended way to work with `cargo login` is via libsecret, but that requires a specific LD_LIBRARY_PATH with this overaly.

This PR fixes this by adding libsecret as a runtime dependency of cargo.

Tested on Linux-aarch64.
