### PR TITLE
Add meta.mainProgram for select components

### DIFF
--- a/lib/mk-component-set.nix
+++ b/lib/mk-component-set.nix
@@ -174,11 +174,8 @@ let
 
       dontStrip = true;
 
-      meta = lib.optionalAttrs (elem pname [ "rustc" "rustfmt-preview" "rust-analyzer-preview" ] ) ({
-        mainProgram = let
-          renamedAttrs = attrsToList (filterAttrs (_: v: v.to == pname) renames);
-          firstName = if renamedAttrs != [] then (head renamedAttrs).name else pname;
-        in firstName;
+      meta = lib.optionalAttrs (elem pname [ "rustc" "rustfmt-preview" "rust-analyzer-preview" "cargo" ] ) ({
+        mainProgram = lib.removeSuffix "-preview" pname;
       });
     };
 

--- a/lib/mk-component-set.nix
+++ b/lib/mk-component-set.nix
@@ -174,7 +174,7 @@ let
 
       dontStrip = true;
 
-      meta = lib.optionalAttrs (elem pname [ "rustc" "rustfmt-preview" "rust-analyzer-preview" "clippy-preview" "miri-preview" ] ) ({
+      meta = lib.optionalAttrs (elem pname [ "rustc" "rustfmt-preview" "rust-analyzer-preview" ] ) ({
         mainProgram = let
           renamedAttrs = attrsToList (filterAttrs (_: v: v.to == pname) renames);
           firstName = if renamedAttrs != [] then (head renamedAttrs).name else pname;

--- a/lib/mk-component-set.nix
+++ b/lib/mk-component-set.nix
@@ -173,6 +173,13 @@ let
       });
 
       dontStrip = true;
+
+      meta = lib.optionalAttrs (elem pname [ "rustc" "rustfmt-preview" "rust-analyzer-preview" "clippy-preview" "miri-preview" ] ) ({
+        mainProgram = let
+          renamedAttrs = attrsToList (filterAttrs (_: v: v.to == pname) renames);
+          firstName = if renamedAttrs != [] then (head renamedAttrs).name else pname;
+        in firstName;
+      });
     };
 
   self = mapAttrs mkComponent srcs;


### PR DESCRIPTION
This would fix #203


Some open questions for me:

- Are these all components one might be interested in?
  - I only added them here conservatively, as if its wrong `getExe` will still happily interpolate the wrong name and it will then give weird errors of non-existent binaries
- How could this be made more maintainable?

I tried to not over-complicate it, but due to the fact that the renames table has its renaming in a more declarative style, its hard to get the information out of it in a straightforward way.


## Alternatives

- An alternative could be to add the meta attribute in an `overrideAttr` in the last step of `mkComponentSet`. As we have access to the 'correct' name.
- Another way could be to introduce another mapping from `component -> <executable name>`. This would be the least error-prone. But I am not sure where it should live.