### PR TITLE
Remove WASI target workaround and fix example in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust-channel: [stable, beta, nightly]
         profile: [minimal, default]
-        nixpkgs-channel: [nixpkgs-unstable, nixos-23.05]
+        nixpkgs-channel: [nixpkgs-unstable, nixos-24.11]
         include:
           # The legacy package, used by compatible functions.
           - os: ubuntu-latest

--- a/default.nix
+++ b/default.nix
@@ -27,7 +27,6 @@ in {
     distRoot = import ./lib/dist-root.nix;
   } // import ./lib/rust-bin.nix {
     inherit lib manifests;
-    inherit (final.rust) toRustTarget;
     inherit (rust-bin) nightly;
     pkgs = final;
   };

--- a/examples/cross-wasi/Makefile
+++ b/examples/cross-wasi/Makefile
@@ -1,6 +1,6 @@
 # This Makefile is expected to be run inside nix-shell.
 
-CARGO_FLAGS := --target wasm32-wasi
+CARGO_FLAGS := --target wasm32-wasip1
 
 .PHONY: all
 all: Cargo.toml Cargo.lock src/main.rs

--- a/examples/cross-wasi/shell.nix
+++ b/examples/cross-wasi/shell.nix
@@ -2,6 +2,15 @@
 (import <nixpkgs> {
   crossSystem = {
     config = "wasm32-wasi";
+
+    # NB. Rust use a different naming convention for target platforms and
+    # differentiates multiple version of WASI specification by using "wasip?".
+    # If this line is omitted, `wasm32-wasip1` (WASI 0.1) is assumed.
+    # See: <https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html>
+    #
+    # If you changed this, also update `CARGO_TARGET_*_RUNNER` below.
+    rust.rustcTarget = "wasm32-wasip1";
+
     # Nixpkgs currently only supports LLVM lld linker for wasm32-wasi.
     useLLVM = true;
   };
@@ -16,7 +25,8 @@ mkShellNoCC {
 
   # This is optional for wasm32-like targets, since rustc will automatically use
   # the bundled `lld` for linking.
-  # CARGO_TARGET_WASM32_WASI_LINKER = "${stdenv.cc.targetPrefix}cc";
-  CARGO_TARGET_WASM32_WASI_RUNNER = "wasmtime";
+  # CARGO_TARGET_WASM32_WASIP1_LINKER =
+
+  CARGO_TARGET_WASM32_WASIP1_RUNNER = "wasmtime run";
 }) {}
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1736320768,
+        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
       pkgs:
       lib.fix (rust-bin: import ./lib/rust-bin.nix {
         inherit lib pkgs;
-        inherit (pkgs.rust) toRustTarget;
         inherit (rust-bin) nightly;
         manifests = mkManifests distRoot;
       });

--- a/lib/rust-bin.nix
+++ b/lib/rust-bin.nix
@@ -3,7 +3,6 @@
 {
   lib,
   pkgs,
-  toRustTarget,
   manifests,
   nightly,
 }:
@@ -23,21 +22,15 @@ let
       (filter (name: set.${name} == null)
         (attrNames set));
 
-  # FIXME: https://github.com/NixOS/nixpkgs/pull/146274
-  toRustTarget' = platform:
-    if platform.isWasi then
-      "${platform.parsed.cpu.name}-wasi"
-    else
-      platform.rust.rustcTarget or (toRustTarget platform);
+  toRustTarget = platform: platform.rust.rustcTarget;
 
   # The platform where `rustc` is running.
-  rustHostPlatform = toRustTarget' stdenv.hostPlatform;
+  rustHostPlatform = toRustTarget stdenv.hostPlatform;
   # The platform of binary which `rustc` produces.
-  rustTargetPlatform = toRustTarget' stdenv.targetPlatform;
+  rustTargetPlatform = toRustTarget stdenv.targetPlatform;
 
   mkComponentSet = callPackage ./mk-component-set.nix {
-    inherit removeNulls;
-    toRustTarget = toRustTarget';
+    inherit removeNulls toRustTarget;
   };
 
   mkAggregated = callPackage ./mk-aggregated.nix {};


### PR DESCRIPTION
The un-versioned `wasm32-wasi` target is removed in favor of `wasm32-wasip?` since Rust 1.84. Examples are updated.

The nixpkgs patch for WASI target name remapping is merged in 24.11. We can also safely remove the workaround.