### PR TITLE
mk-aggregated: overridable stdenv

### DIFF
--- a/lib/mk-aggregated.nix
+++ b/lib/mk-aggregated.nix
@@ -1,8 +1,10 @@
-{ lib, stdenv, symlinkJoin, pkgsTargetTarget, bash, curl, rustc }:
-{ pname, version, date, selectedComponents, availableComponents ? selectedComponents }:
+{ lib, stdenv, symlinkJoin, pkgsHostTarget, pkgsTargetTarget, bash, curl, rustc }:
+{ pname, version, date, stdenvSelector, selectedComponents, availableComponents ? selectedComponents}:
 let
   inherit (lib) optional;
   inherit (stdenv) targetPlatform;
+  stdenvHostTarget = stdenvSelector pkgsHostTarget;
+  stdenvTargetTarget = stdenvSelector pkgsTargetTarget;
 in
 symlinkJoin {
   name = pname + "-" + version;
@@ -29,13 +31,13 @@ symlinkJoin {
 
   # CC for build script linking.
   # Workaround: should be `pkgsHostHost.cc` but `stdenv`'s cc itself have -1 offset.
-  depsHostHostPropagated = [ stdenv.cc ];
+  depsHostHostPropagated = [ stdenvHostTarget.cc ];
 
   # CC for crate linking.
   # Workaround: should be `pkgsHostTarget.cc` but `stdenv`'s cc itself have -1 offset.
   # N.B. WASM targets don't need our CC.
   propagatedBuildInputs =
-    optional (!targetPlatform.isWasm) pkgsTargetTarget.stdenv.cc;
+    optional (!targetPlatform.isWasm) stdenvTargetTarget.cc;
 
   # Link dependency for target, required by darwin std.
   depsTargetTargetPropagated =

--- a/lib/rust-bin.nix
+++ b/lib/rust-bin.nix
@@ -289,10 +289,11 @@ let
       ) allPlatformSet;
 
     mkProfile = name: profileComponents:
-      makeOverridable ({ extensions, targets, targetExtensions }:
+      makeOverridable ({ extensions, targets, targetExtensions, stdenvSelector }:
         mkAggregated {
           pname = "rust-${name}";
           inherit (manifest) version date;
+          inherit stdenvSelector;
           availableComponents = componentSet.${rustHostPlatform};
           selectedComponents = resolveComponents {
             name = "rust-${name}-${manifest.version}";
@@ -309,6 +310,7 @@ let
         extensions = [];
         targets = [];
         targetExtensions = [];
+        stdenvSelector = pkgs: pkgs.stdenv;
       };
 
     profiles = mapAttrs mkProfile manifest.profiles;


### PR DESCRIPTION
I'd like to be able to override `stdenv` so that for example all C dependencies get built with clang instead of gcc.

This is quite tricky to do as you can't just pass any `stdenv` override to the toolchain because the toolchain can be placed into different contexts (e.g. `nativeBuildInputs` where splicing is offset by -1).

I haven't been able to find a better solution than accepting a `stdenvSelector` function. This picks the stdenv from the context of the toolchain derivation so it's always correctly offset.

```nix
toolchain.override { stdenvSelector = pkgs: pkgs.llvmPackages_19.stdenv; }
```

The selector function also allows you to pick a different `stdenv` depending on the platform, which could be useful when cross-compiling, say you want a different stdenv per build/host/target platform:

```nix
toolchain.override { stdenvSelector = pkgs: if pkgs.stdenv.isDarwin then pkgs.llvmPackages_19.stdenv else pkgs.stdenv; }
```