### PR TITLE
Add flake to cross-mingw example

### DIFF
--- a/docs/cross_compilation.md
+++ b/docs/cross_compilation.md
@@ -88,5 +88,12 @@ To try it,
 2. `nix develop` to enter the development environment.
 3. `make run` to build and run the program in an emulator.
 
+Another example without `mkRustBin` can be seen in
+[`examples/cross-mingw/flake.nix`](../examples/cross-mingw/flake.nix) (cross-compiling to Windows).
+To try it,
+1. `cd` into `examples/cross-mingw`.
+2. `nix develop` to enter the development environment.
+3. `make run` to build and run the program with Wine.
+
 [wiki-cross]: https://wiki.nixos.org/wiki/Cross_Compiling#How_to_specify_dependencies
 [flake-cross-issue]: https://github.com/NixOS/nix/issues/5157

--- a/examples/cross-mingw/flake.nix
+++ b/examples/cross-mingw/flake.nix
@@ -1,0 +1,38 @@
+# Example flake for `nix develop`.
+# See docs/cross_compilation.md for details.
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, ... }:
+  let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {
+      inherit system;
+      overlays = [ (import rust-overlay) ];
+      crossSystem.config = "x86_64-w64-mingw32";
+    };
+  in
+  {
+    devShells.${system} = {
+      default = pkgs.callPackage (
+        { mkShell, stdenv, rust-bin, windows, wine64 }:
+        mkShell {
+          nativeBuildInputs = [
+            rust-bin.stable.latest.minimal
+          ];
+
+          depsBuildBuild = [ wine64 ];
+          buildInputs = [ windows.pthreads ];
+
+          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER = "${stdenv.cc.targetPrefix}cc";
+          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER = "wine64";
+      }) {};
+    };
+  };
+}


### PR DESCRIPTION
Adds a flake to the cross-mingw example.

Without `mkRustBin` for now, as I was not able to understand what benefit(s) it brings me, plus I find the syntax more difficult to read/understand.

Let me know if you would like this flake to use `mkRustBin` too, and if you're extra nice, attempt to explain why one should use it :smile: 

But even then, it might be nice to have (at least) one flake example that shows how it could look without `mkRustBin`.