### PR TITLE
Make cross compilation flake example follow code more closely

### DIFF
--- a/docs/cross_compilation.md
+++ b/docs/cross_compilation.md
@@ -76,9 +76,14 @@ get corresponding compiler toolchains for them.
 let
   pkgs = nixpkgs.legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform;
   rust-bin = rust-overlay.lib.mkRustBin { } pkgs.buildPackages;
-in pkgs.mkShell {
-  nativeBuildInputs = [ rust-bin.stable.latest.minimal ];
-}
+in
+# Need `callPackage` here, see https://github.com/NixOS/nixpkgs/issues/49526
+pkgs.callPackage (
+  { mkShell }:
+  mkShell {
+    nativeBuildInputs = [ rust-bin.stable.latest.minimal ];
+  }
+) { }
 ```
 
 The full example can be seen in


### PR DESCRIPTION
I noticed that the nix code block under the flakes section in `docs/cross_compilation.md` is missing the crucial `pkgs.callPackage`-part. It is explained above in the non-flake-section, and also used in the actual example flake that is referenced below (although without explanation), but missing here.

This really confused me, as I skipped the non-flakes-section, as I knew I wanted a flake solution, looked at the examples, did not understand the seemingly-redundant `pkgs.callPackage` call, left it out in my own project's flake and then wondered why it doesn't work. I only later realized the importance of this `pkgs.callPackage` call, and also that it was documented in the non-flakes-section, which I skipped.

So hopefully this will save someone from reliving what just happened to me.