### PR TITLE
docs(README): deduplicate Nixpkgs in dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,14 @@ Running `nix develop` will create a shell with the default beta Rust toolchain i
 
   inputs = {
     nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url  = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ (import rust-overlay) ];


### PR DESCRIPTION
The NixOS configuration example has `inputs.nixpkgs.follows = "nixpkgs";` to avoid a duplicated Nixpkgs input, but the `nix develop` example doesn't; this PR fixes that.