### PR TITLE
fix: Copy extra components on darwin

### DIFF
--- a/lib/mk-aggregated.nix
+++ b/lib/mk-aggregated.nix
@@ -69,7 +69,8 @@ symlinkJoin {
     shopt nullglob
     for file in \
       $out/bin/{rustc,rustdoc,miri,cargo-miri,cargo-clippy,clippy-driver} \
-      $out/lib/{librustc_driver*,rustlib/*/lib/librustc_driver*}
+      $out/lib/{librustc_driver*,rustlib/*/lib/librustc_driver*} \
+      $out/lib/rustlib/*/bin/{rust-lld,rust-objcopy,wasm-component-ld}
     do
       if [ -e $file ]; then
         cp --remove-destination "$(realpath -e $file)" $file

--- a/lib/mk-aggregated.nix
+++ b/lib/mk-aggregated.nix
@@ -69,8 +69,7 @@ symlinkJoin {
     shopt nullglob
     for file in \
       $out/bin/{rustc,rustdoc,miri,cargo-miri,cargo-clippy,clippy-driver} \
-      $out/lib/{librustc_driver*,rustlib/*/lib/librustc_driver*} \
-      ${lib.optionalString stdenv.isDarwin ''$out/lib/rustlib/*/bin/{rust-lld,rust-objcopy,wasm-component-ld}''}
+      $out/lib/{librustc_driver*,rustlib/*/lib/librustc_driver*}
     do
       if [ -e $file ]; then
         cp --remove-destination "$(realpath -e $file)" $file

--- a/lib/mk-aggregated.nix
+++ b/lib/mk-aggregated.nix
@@ -70,7 +70,7 @@ symlinkJoin {
     for file in \
       $out/bin/{rustc,rustdoc,miri,cargo-miri,cargo-clippy,clippy-driver} \
       $out/lib/{librustc_driver*,rustlib/*/lib/librustc_driver*} \
-      $out/lib/rustlib/*/bin/{rust-lld,rust-objcopy,wasm-component-ld}
+      ${lib.optionalString stdenv.isDarwin ''$out/lib/rustlib/*/bin/{rust-lld,rust-objcopy,wasm-component-ld}''}
     do
       if [ -e $file ]; then
         cp --remove-destination "$(realpath -e $file)" $file

--- a/lib/mk-component-set.nix
+++ b/lib/mk-component-set.nix
@@ -143,6 +143,25 @@ let
           fi
         ''
 
+        # Darwin rustlib helper tools live under `lib/rustlib/<target>/bin`
+        # and use `@loader_path/../lib`, so expose rustc's LLVM dylib there.
+        + optionalString (hostPlatform.isDarwin && pname == "rustc") ''
+          if [[ -e "$out/lib/libLLVM.dylib" ]]; then
+            for binDir in "$out"/lib/rustlib/*/bin; do
+              if [[ ! -d "$binDir" ]]; then
+                continue
+              fi
+              if [[ -e "$binDir/rust-lld" || -e "$binDir/rust-objcopy" || -e "$binDir/wasm-component-ld" ]]; then
+                libDir="$(dirname "$binDir")/lib"
+                mkdir -p "$libDir"
+                if [[ ! -e "$libDir/libLLVM.dylib" && ! -L "$libDir/libLLVM.dylib" ]]; then
+                  ln -s ../../../libLLVM.dylib "$libDir/libLLVM.dylib"
+                fi
+              fi
+            done
+          fi
+        ''
+
         # Wrap the shipped `rust-lld` (lld), which is used by default on some targets.
         # Unfortunately there is no hook to conveniently wrap CC tools inside
         # derivation and `wrapBintools` is designed for wrapping a standalone

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -237,15 +237,17 @@ optionalAttrs
     targets = [ "x86_64-apple-darwin" ];
     targetExtensions = [ "rust-docs" ];
   };
-  aarch64-darwin-rustlib-tools-shared-llvm = pkgs.runCommand "aarch64-darwin-rustlib-tools-shared-llvm" { } ''
-    for rustlib in \
-      "${nightly.${sharedLlvmNightly}.rustc}/lib/rustlib/${rustHostPlatform}" \
-      "${nightly.${sharedLlvmNightly}.default}/lib/rustlib/${rustHostPlatform}"
-    do
-      "$rustlib/bin/rust-lld" -flavor wasm --version
-      "$rustlib/bin/rust-objcopy" --version
-      "$rustlib/bin/wasm-component-ld" --version
-    done
-    touch "$out"
-  '';
+  aarch64-darwin-rustlib-tools-shared-llvm =
+    pkgs.runCommand "aarch64-darwin-rustlib-tools-shared-llvm" { }
+      ''
+        for rustlib in \
+          "${nightly.${sharedLlvmNightly}.rustc}/lib/rustlib/${rustHostPlatform}" \
+          "${nightly.${sharedLlvmNightly}.default}/lib/rustlib/${rustHostPlatform}"
+        do
+          "$rustlib/bin/rust-lld" -flavor wasm --version
+          "$rustlib/bin/rust-objcopy" --version
+          "$rustlib/bin/wasm-component-ld" --version
+        done
+        touch "$out"
+      '';
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -48,6 +48,7 @@ let
     date = "2026-01-10";
     version = "1.93.0-beta.6-2026-01-10";
   };
+  sharedLlvmNightly = "2026-06-02";
 
 in
 # Check only tier 1 targets.
@@ -236,4 +237,15 @@ optionalAttrs
     targets = [ "x86_64-apple-darwin" ];
     targetExtensions = [ "rust-docs" ];
   };
+  aarch64-darwin-rustlib-tools-shared-llvm = pkgs.runCommand "aarch64-darwin-rustlib-tools-shared-llvm" { } ''
+    for rustlib in \
+      "${nightly.${sharedLlvmNightly}.rustc}/lib/rustlib/${rustHostPlatform}" \
+      "${nightly.${sharedLlvmNightly}.default}/lib/rustlib/${rustHostPlatform}"
+    do
+      "$rustlib/bin/rust-lld" -flavor wasm --version
+      "$rustlib/bin/rust-objcopy" --version
+      "$rustlib/bin/wasm-component-ld" --version
+    done
+    touch "$out"
+  '';
 }


### PR DESCRIPTION
Hi! After updating to a fresh version of rust I've started getting these kinds of errors from `rust-lld` on macos:

```
dyld[57979]: Library not loaded: @rpath/libLLVM.dylib
  Referenced from: <1A2A643B-408F-3C7A-B8A2-DC5EDCCD6D11> /nix/store/dsd8a65z7w5dl4i0h8g45qkc2hmk2vva-rustc-1.98.0-nightly-2026-06-02-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/rust-lld
  Reason: tried: '/nix/store/dsd8a65z7w5dl4i0h8g45qkc2hmk2vva-rustc-1.98.0-nightly-2026-06-02-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/../lib/libLLVM.dylib' (no such file), '/Users/runner/work/rust/rust/build/aarch64-apple-darwin/llvm/lib/libLLVM.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/rust/rust/build/aarch64-apple-darwin/llvm/lib/libLLVM.dylib' (no such file), '/nix/store/dsd8a65z7w5dl4i0h8g45qkc2hmk2vva-rustc-1.98.0-nightly-2026-06-02-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/../lib/libLLVM.dylib' (no such file), '/Users/runner/work/rust/rust/build/aarch64-apple-darwin/llvm/lib/libLLVM.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/rust/rust/build/aarch64-apple-darwin/llvm/lib/libLLVM.dylib' (no such file)
```

It looks like recent versions of helper binaries link dynamically to `libLLVM.dylib`. The tools live under  `lib/rustlib/<target>/bin` and their rpath include `@loader_path/../lib`, so dyld expects LLVM at `lib/rustlib/<target>/lib/libLLVM.dylib`. However, the rustc component provides `libLLVM.dylib` under: `lib/libLLVM.dylib`, current fix symlinks the `libLLVM.dylib` into the corresponding relative path.

This issue was likely triggered by:
https://github.com/rust-lang/rust/pull/157205

There is also
https://github.com/rust-lang/rust/pull/157557
which will likely affect `x86_64-darwin` as well.

I've tested the fix on `aarch64-darwin` and `x86_64-linux` manually (although with `llvm-tools-preview` component enabled).