### PR TITLE
Ensure the enzyme component links to libLLVM*

### DIFF
--- a/lib/mk-component-set.nix
+++ b/lib/mk-component-set.nix
@@ -40,6 +40,7 @@ let
       # These components link to `librustc_driver*.so` or `libLLVM*.so`.
       linksToRustc = elem pname [
         "clippy-preview"
+        "enzyme-preview"
         "miri-preview"
         "rls-preview"
         "rust-analyzer-preview"


### PR DESCRIPTION
Enzyme requires libLLVM*. I'm currently testing other functionality to make sure we can build stuff with enzyme but so far it seems to work.